### PR TITLE
docs: Use `cargo add` instead of referencing explicit versions

### DIFF
--- a/book/getting_started.md
+++ b/book/getting_started.md
@@ -1,5 +1,10 @@
 # Getting Started
 
+## Install Rust
+
+First, make sure you've installed a [Rust toolchain](https://rustup.rs), which
+should install [`cargo`](https://doc.rust-lang.org/cargo/) for you.
+
 ## Install Verilator
 
 The current integrations for Verilog and [Spade][spade] use a [Verilator][verilator] backend, which you need to install.
@@ -13,16 +18,6 @@ apt-get install verilator
 ```
 
 Check this [list of packages](https://repology.org/project/verilator/versions) to find one for your operating system and view the [official installation instructions](https://veripool.org/guide/latest/install.html) if you need more help.
-
-## Install Marlin
-
-First, make sure you've installed a [Rust toolchain](https://rustup.rs), which
-should come packaged with [`cargo`](https://doc.rust-lang.org/cargo/). Then,
-simply run:
-
-```shell
-cargo install marlin
-```
 
 You're done! Now, it's time to [get started testing some Verilog](./verilog/quickstart.md).
 

--- a/book/spade/quickstart.md
+++ b/book/spade/quickstart.md
@@ -61,19 +61,9 @@ its outputs.
 
 ```shell
 cargo init --lib
-vi lib.rs
-mkdir tests
-vi tests/simple_test.rs
-```
-
-In the `Cargo.toml` generated, we'll want to add some dependencies:
-
-```toml
-# file: Cargo.toml
-[dependencies]
-# other dependencies...
-marlin = { version = "0.2.0", features = ["spade"] }
-snafu = "0.8.5"
+cargo add marlin --features spade --dev
+cargo add colog --dev
+cargo add snafu --dev
 ```
 
 In the `lib.rs`, we'll create the binding to our Spade module:
@@ -90,6 +80,11 @@ This tells Marlin that the `struct Main` should be linked to the `main` entity
 in our Spade file.
 
 Finally, we'll want to actually write the code that drives our hardware in `simple_test.rs`:
+
+```shell
+mkdir tests
+vi tests/simple_test.rs
+```
 
 ```rust
 // file: tests/simple_test.rs

--- a/book/verilog/dpi.md
+++ b/book/verilog/dpi.md
@@ -59,22 +59,23 @@ endmodule
 We'll create a new Rust project:
 
 ```shell
-mkdir test
-vi Cargo.toml
-vi tests/dpi_test.rs
+cargo init --lib
 ```
 
 Next, we'll add Marlin and other desired dependencies.
 
-```toml
-# file: Cargo.toml
-[dependencies]
-# other dependencies...
-marlin = "0.2.0" # no language features needed
-snafu = "0.8.5"
+```shell
+cargo add marlin --features verilog --dev
+cargo add colog --dev
+cargo add snafu --dev
 ```
 
 Finally, we need the Rust file where we define the DPI function and drive the model.
+
+```shell
+mkdir tests
+vi tests/dpi_test.rs
+```
 
 ```rust
 // file: tests/dpi_test.rs

--- a/book/verilog/dynamic.md
+++ b/book/verilog/dynamic.md
@@ -54,18 +54,15 @@ endmodule
 We'll create a new Rust project:
 
 ```shell
-mkdir test
-vi Cargo.toml
-vi tests/dynamic_test.rs
+cargo init --lib
 ```
 
 Next, we'll add Marlin and other desired dependencies.
-```toml
-# file: Cargo.toml
-[dependencies]
-# other dependencies...
-marlin = { version = "0.2.0", features = ["verilog"] }
-snafu = "0.8.5"
+
+```shell
+cargo add marlin --dev # no features sneeded
+cargo add colog --dev
+cargo add snafu --dev
 ```
 
 We will illustrate using dynamic models by implementing the exact same test as
@@ -74,6 +71,11 @@ we did in the [Verilog quickstart](./quickstart.md).
 The code for dynamic models is slightly more verbose.
 It's not necessarily meant for human usage, though; this API is better suited for
 using Marlin as a library (e.g., writing an interpreter).
+
+```shell
+mkdir tests
+vi tests/dynamic_test.rs
+```
 
 ```rust
 // file: tests/simple_test.rs

--- a/book/verilog/quickstart.md
+++ b/book/verilog/quickstart.md
@@ -57,19 +57,14 @@ We'll initialize a Rust project:
 
 ```shell
 cargo init --lib
-vi src/lib.rs
-vi test/simple_test.rs
 ```
 
 In the `Cargo.toml` generated, we'll want to add some dependencies:
 
-```toml
-# file: Cargo.toml
-[dependencies]
-# other dependencies...
-marlin = { version = "0.2.0", features = ["verilog"] }
-snafu = "0.8.5" # optional, whatever version
-colog = "1.3.0" # optional, whatever version
+```shell
+cargo add marlin --features verilog
+cargo add colog --dev
+cargo add snafu --dev
 ```
 
 The only required crate is `marlin`, but I strongly recommend at this stage of
@@ -94,7 +89,16 @@ pub struct Main;
 This tells Marlin that the `struct Main` should be linked to the `main` module
 in our Verilog file.
 
+It's not necessary to even use the `lib.rs` -- you can put `marlin` in your
+`[dev-dependencies]` section in `Cargo.toml` and construct the bindings directly
+in your test files.
+
 Finally, we'll want to actually write the code that drives our project in `simple_test.rs`:
+
+```shell
+mkdir tests
+vi tests/simple_test.rs
+```
 
 ```rust
 // file: tests/simple_test.rs


### PR DESCRIPTION
Closes #74