### PR TITLE
feat(verilog): Support `bool` and distinguish signed/unsigned integers over DPI

### DIFF
--- a/book/verilog/dpi.md
+++ b/book/verilog/dpi.md
@@ -145,3 +145,5 @@ Then, we told the runtime about this function:
     )?;
 
 ```
+
+See the [documentation for the `#[verilog::dpi]`](https://docs.rs/marlin/latest/marlin/verilog/attr.dpi.html) macro for more details.

--- a/examples/verilog-project/src/dpi.sv
+++ b/examples/verilog-project/src/dpi.sv
@@ -1,4 +1,4 @@
-import "DPI-C" function void three(output int out);
+import "DPI-C" function void three(output int unsigned out);
 
 module dpi_main(output logic[31:0] out);
     int a = 0;

--- a/examples/verilog-project/src/dpi.sv
+++ b/examples/verilog-project/src/dpi.sv
@@ -1,19 +1,10 @@
-import "DPI-C" function void three(output int unsigned out);
-import "DPI-C" function void check_three(input int in);
-import "DPI-C" function void Bool(output bit b);
+import "DPI-C" function void set_out(output int out);
 
-module dpi_main(output logic out);
+module dpi_main(output logic[31:0] out);
     int a = 0;
-    logic b = 0;
-
     initial begin
-        three(a);
-        check_three(a);
+        set_out(a);
         $display("%d", a);
-
-        Bool(b);
-        $display("%d", b);
-        out = b;
+        out = a;
     end
-    
 endmodule

--- a/examples/verilog-project/src/dpi.sv
+++ b/examples/verilog-project/src/dpi.sv
@@ -1,10 +1,19 @@
 import "DPI-C" function void three(output int unsigned out);
+import "DPI-C" function void check_three(input int in);
+import "DPI-C" function void Bool(output bit b);
 
-module dpi_main(output logic[31:0] out);
+module dpi_main(output logic out);
     int a = 0;
+    logic b = 0;
+
     initial begin
         three(a);
+        check_three(a);
         $display("%d", a);
-        out = a;
+
+        Bool(b);
+        $display("%d", b);
+        out = b;
     end
+    
 endmodule

--- a/examples/verilog-project/src/lib.rs
+++ b/examples/verilog-project/src/lib.rs
@@ -20,6 +20,9 @@ pub struct Main;
 #[verilog(src = "src/dpi.sv", name = "dpi_main")]
 pub struct DpiMain;
 
+#[verilog(src = "src/more_dpi.sv", name = "dpi_main")]
+pub struct MoreDpiMain;
+
 pub mod enclosed {
     use marlin::verilog::prelude::*;
 

--- a/examples/verilog-project/src/more_dpi.sv
+++ b/examples/verilog-project/src/more_dpi.sv
@@ -1,0 +1,21 @@
+import "DPI-C" function void set_unsigned_int_out(output int unsigned out);
+import "DPI-C" function void check_unsigned_int_out(input int unsigned in);
+import "DPI-C" function void set_bool_out(output bit b);
+
+module dpi_main(output logic[31:0] int_out, output logic bool_out);
+    int a = 0;
+    
+    logic b = 0;
+
+    initial begin
+        set_unsigned_int_out(a);
+        check_unsigned_int_out(a);
+        $display("%d", a);
+
+        set_bool_out(b);
+        $display("%d", b);
+
+        int_out = a;
+        bool_out = b;
+    end
+endmodule

--- a/examples/verilog-project/tests/dpi_tutorial.rs
+++ b/examples/verilog-project/tests/dpi_tutorial.rs
@@ -14,31 +14,23 @@
 
 use std::env;
 
-use example_verilog_project::DpiMain;
+use example_verilog_project::{DpiMain, MoreDpiMain};
 use marlin::{
     verilator::{VerilatorRuntime, VerilatorRuntimeOptions},
     verilog::prelude::*,
 };
 use snafu::Whatever;
 
-#[verilog::dpi]
-pub extern "C" fn three(output: &mut u32) {
-    *output = 3;
-}
+const SET_OUT_TO: i32 = 3;
 
 #[verilog::dpi]
-pub extern "C" fn check_three(input: i32) {
-    assert_eq!(input, 3);    
-}
-
-#[verilog::dpi]
-pub extern "C" fn Bool(output: &mut bool) {
-    *output = true;
+pub extern "C" fn set_out(output: &mut i32) {
+    *output = SET_OUT_TO;
 }
 
 #[test]
 #[snafu::report]
-fn main() -> Result<(), Whatever> {
+fn main_tutorial() -> Result<(), Whatever> {
     if env::var("RUST_LOG").is_ok() {
         env_logger::init();
     }
@@ -47,14 +39,52 @@ fn main() -> Result<(), Whatever> {
         "artifacts".into(),
         &["src/dpi.sv".as_ref()],
         &[],
-        [three, check_three, Bool],
+        [set_out],
         VerilatorRuntimeOptions::default_logging(),
     )?;
 
     let mut main = runtime.create_model::<DpiMain>()?;
     main.eval();
 
-    assert_eq!(main.out, 1);
+    assert_eq!(main.out, SET_OUT_TO as u32);
+
+    Ok(())
+}
+
+const SET_UNSIGNED_INT_OUT_TO: u32 = 5;
+const SET_BOOL_OUT_TO: bool = true;
+
+#[verilog::dpi]
+pub extern "C" fn set_unsigned_int_out(output: &mut u32) {
+    *output = SET_UNSIGNED_INT_OUT_TO;
+}
+
+#[verilog::dpi]
+pub extern "C" fn check_unsigned_int_out(input: u32) {
+    assert_eq!(input, SET_UNSIGNED_INT_OUT_TO);
+}
+
+#[verilog::dpi]
+pub extern "C" fn set_bool_out(output: &mut bool) {
+    *output = SET_BOOL_OUT_TO;
+}
+
+#[test]
+//#[snafu::report]
+fn other_test() -> Result<(), Whatever> {
+    let runtime = VerilatorRuntime::new(
+        "artifacts".into(),
+        &["src/more_dpi.sv".as_ref()],
+        &[],
+        [set_unsigned_int_out, check_unsigned_int_out, set_bool_out],
+        VerilatorRuntimeOptions::default_logging(),
+    )?;
+
+    let mut main = runtime.create_model::<MoreDpiMain>()?;
+    main.eval();
+
+    assert_eq!(main.int_out, SET_UNSIGNED_INT_OUT_TO);
+    assert_eq!(main.bool_out, SET_BOOL_OUT_TO as u8);
 
     Ok(())
 }

--- a/examples/verilog-project/tests/dpi_tutorial.rs
+++ b/examples/verilog-project/tests/dpi_tutorial.rs
@@ -22,8 +22,18 @@ use marlin::{
 use snafu::Whatever;
 
 #[verilog::dpi]
-pub extern "C" fn three(out: &mut u32) {
-    *out = 3;
+pub extern "C" fn three(output: &mut u32) {
+    *output = 3;
+}
+
+#[verilog::dpi]
+pub extern "C" fn check_three(input: i32) {
+    assert_eq!(input, 3);    
+}
+
+#[verilog::dpi]
+pub extern "C" fn Bool(output: &mut bool) {
+    *output = true;
 }
 
 #[test]
@@ -37,13 +47,14 @@ fn main() -> Result<(), Whatever> {
         "artifacts".into(),
         &["src/dpi.sv".as_ref()],
         &[],
-        [three],
+        [three, check_three, Bool],
         VerilatorRuntimeOptions::default_logging(),
     )?;
 
     let mut main = runtime.create_model::<DpiMain>()?;
     main.eval();
-    assert_eq!(main.out, 3);
+
+    assert_eq!(main.out, 1);
 
     Ok(())
 }

--- a/language-support/verilog-macro/src/lib.rs
+++ b/language-support/verilog-macro/src/lib.rs
@@ -7,7 +7,7 @@
 use std::{env, fmt, path::PathBuf};
 
 use marlin_verilog_macro_builder::{
-    build_verilated_struct, parse_verilog_ports, MacroArgs,
+    MacroArgs, build_verilated_struct, parse_verilog_ports,
 };
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};

--- a/language-support/verilog-macro/src/lib.rs
+++ b/language-support/verilog-macro/src/lib.rs
@@ -76,11 +76,10 @@ impl fmt::Display for DPIPrimitiveType {
 impl DPIPrimitiveType {
     fn as_c(&self) -> &'static str {
         match self {
-            // verilator uses signed for everything it seems
-            DPIPrimitiveType::U8 => "int8_t",
-            DPIPrimitiveType::U16 => "int16_t",
-            DPIPrimitiveType::U32 => "int32_t",
-            DPIPrimitiveType::U64 => "int64_t",
+            DPIPrimitiveType::U8 => "uint8_t",
+            DPIPrimitiveType::U16 => "uint16_t",
+            DPIPrimitiveType::U32 => "uint32_t",
+            DPIPrimitiveType::U64 => "uint64_t",
             DPIPrimitiveType::I8 => "int8_t",
             DPIPrimitiveType::I16 => "int16_t",
             DPIPrimitiveType::I32 => "int32_t",

--- a/language-support/verilog-macro/src/lib.rs
+++ b/language-support/verilog-macro/src/lib.rs
@@ -47,6 +47,7 @@ pub fn verilog(args: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 enum DPIPrimitiveType {
+    Bool,
     U8,
     U16,
     U32,
@@ -60,6 +61,7 @@ enum DPIPrimitiveType {
 impl fmt::Display for DPIPrimitiveType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            DPIPrimitiveType::Bool => "bool",
             DPIPrimitiveType::U8 => "u8",
             DPIPrimitiveType::U16 => "u16",
             DPIPrimitiveType::U32 => "u32",
@@ -76,6 +78,7 @@ impl fmt::Display for DPIPrimitiveType {
 impl DPIPrimitiveType {
     fn as_c(&self) -> &'static str {
         match self {
+            DPIPrimitiveType::Bool => "svBit",
             DPIPrimitiveType::U8 => "uint8_t",
             DPIPrimitiveType::U16 => "uint16_t",
             DPIPrimitiveType::U32 => "uint32_t",
@@ -108,6 +111,7 @@ fn parse_dpi_primitive_type(
         .to_string()
         .as_str()
     {
+        "bool" => Ok(DPIPrimitiveType::Bool),
         "u8" => Ok(DPIPrimitiveType::U8),
         "u16" => Ok(DPIPrimitiveType::U16),
         "u32" => Ok(DPIPrimitiveType::U32),

--- a/verilator/src/dpi.rs
+++ b/verilator/src/dpi.rs
@@ -4,6 +4,11 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at https://mozilla.org/MPL/2.0/.
 
+//! See the [`#[verilog::dpi]`](https://docs.rs/marlin/latest/marlin/verilog/attr.dpi.html) macro for details.
+
+/// A `&'static dyn DpiFunction` represents a Rust function suitable for use in
+/// Verilator DPI. See the [`#[verilog::dpi]`](https://docs.rs/marlin/latest/marlin/verilog/attr.dpi.html)
+/// macro for details.
 pub trait DpiFunction: Sync {
     /// The Rust-declared name of the DPI function. This should be taken to be
     /// equivalent to the name given for the DPI C function in Verilog


### PR DESCRIPTION
fix #108 