### PR TITLE
fix: Prevent `#[spade]` and `#[veryl]` from hanging in absence of manifest

### DIFF
--- a/language-support/spade-macro/src/lib.rs
+++ b/language-support/spade-macro/src/lib.rs
@@ -13,7 +13,7 @@ use proc_macro::TokenStream;
 use spade_parser::logos::Logos;
 
 fn search_for_swim_toml(mut start: Utf8PathBuf) -> Option<Utf8PathBuf> {
-    while !start.as_str().is_empty() {
+    while !start.parent().is_none() {
         if start.join("swim.toml").is_file() {
             return Some(start.join("swim.toml"));
         }

--- a/language-support/spade-macro/src/lib.rs
+++ b/language-support/spade-macro/src/lib.rs
@@ -13,7 +13,7 @@ use proc_macro::TokenStream;
 use spade_parser::logos::Logos;
 
 fn search_for_swim_toml(mut start: Utf8PathBuf) -> Option<Utf8PathBuf> {
-    while !start.parent().is_none() {
+    while start.parent().is_some() {
         if start.join("swim.toml").is_file() {
             return Some(start.join("swim.toml"));
         }

--- a/language-support/spade/src/lib.rs
+++ b/language-support/spade/src/lib.rs
@@ -27,7 +27,7 @@ pub mod prelude {
 }
 
 fn search_for_swim_toml(mut start: Utf8PathBuf) -> Option<Utf8PathBuf> {
-    while !start.as_str().is_empty() {
+    while !start.parent().is_none() {
         if start.join("swim.toml").is_file() {
             return Some(start.join("swim.toml"));
         }

--- a/language-support/spade/src/lib.rs
+++ b/language-support/spade/src/lib.rs
@@ -27,7 +27,7 @@ pub mod prelude {
 }
 
 fn search_for_swim_toml(mut start: Utf8PathBuf) -> Option<Utf8PathBuf> {
-    while !start.parent().is_none() {
+    while start.parent().is_some() {
         if start.join("swim.toml").is_file() {
             return Some(start.join("swim.toml"));
         }

--- a/language-support/veryl-macro/src/lib.rs
+++ b/language-support/veryl-macro/src/lib.rs
@@ -20,7 +20,7 @@ use veryl_parser::{
 };
 
 fn search_for_veryl_toml(mut start: Utf8PathBuf) -> Option<Utf8PathBuf> {
-    while !start.parent().is_none() {
+    while start.parent().is_some() {
         if start.join("Veryl.toml").is_file() {
             return Some(start.join("Veryl.toml"));
         }

--- a/language-support/veryl-macro/src/lib.rs
+++ b/language-support/veryl-macro/src/lib.rs
@@ -20,7 +20,7 @@ use veryl_parser::{
 };
 
 fn search_for_veryl_toml(mut start: Utf8PathBuf) -> Option<Utf8PathBuf> {
-    while !start.as_str().is_empty() {
+    while !start.parent().is_none() {
         if start.join("Veryl.toml").is_file() {
             return Some(start.join("Veryl.toml"));
         }

--- a/language-support/veryl/src/lib.rs
+++ b/language-support/veryl/src/lib.rs
@@ -25,7 +25,7 @@ pub mod prelude {
 }
 
 fn search_for_veryl_toml(mut start: Utf8PathBuf) -> Option<Utf8PathBuf> {
-    while !start.as_str().is_empty() {
+    while !start.parent().is_none() {
         if start.join("Veryl.toml").is_file() {
             return Some(start.join("Veryl.toml"));
         }

--- a/language-support/veryl/src/lib.rs
+++ b/language-support/veryl/src/lib.rs
@@ -25,7 +25,7 @@ pub mod prelude {
 }
 
 fn search_for_veryl_toml(mut start: Utf8PathBuf) -> Option<Utf8PathBuf> {
-    while !start.parent().is_none() {
+    while start.parent().is_some() {
         if start.join("Veryl.toml").is_file() {
             return Some(start.join("Veryl.toml"));
         }


### PR DESCRIPTION
Both spade and veryl proc-macros would hang if there was no respective manifest file to be found by the search. This patch fixes that :)