### PR TITLE
feat(verilator): Allow specifying C++ standard used by Verilator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,8 @@ jobs:
           else
             sudo apt-get install -y verilator
           fi
+      - name: Set compiler flags
+        run: echo "CXXFLAGS=-std=c++17" >> $GITHUB_ENV
       - name: Manual test
         run: |
           cd examples/verilog-project

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,6 @@ jobs:
           else
             sudo apt-get install -y verilator
           fi
-      - name: Set compiler flags
-        run: echo "CXXFLAGS=-std=c++17" >> $GITHUB_ENV
       - name: Manual test
         run: |
           cd examples/verilog-project

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 docs/
 version.txt
 *.vcd
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Still, a lot of these are less than optimal.
 - [Rust](https://rustup.rs), 2021 edition
 - [`verilator`](https://verilator.org/guide/latest/install.html), 5.025 or later
    - `make`, e.g. [GNU Make](https://www.gnu.org/software/make/)
+- A C++ compiler that `verilator` can find; may need to [support at least C++14](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4296.pdf).
 
 ## 📦 Install
 

--- a/verilator/src/build_library.rs
+++ b/verilator/src/build_library.rs
@@ -14,11 +14,11 @@
 use std::{fmt::Write, fs, process::Command};
 
 use camino::{Utf8Path, Utf8PathBuf};
-use snafu::{prelude::*, Whatever};
+use snafu::{Whatever, prelude::*};
 
 use crate::{
-    dpi::DpiFunction, PortDirection, VerilatedModelConfig,
-    VerilatorRuntimeOptions,
+    PortDirection, VerilatedModelConfig, VerilatorRuntimeOptions,
+    dpi::DpiFunction,
 };
 
 fn build_ffi_for_tracing(
@@ -142,8 +142,8 @@ extern "C" {{
                 lsb,
                 if width > 64 {
                     format!(", {}", width.div_ceil(32)) // words are 32 bits
-                                                        // according to header
-                                                        // file
+                // according to header
+                // file
                 } else {
                     "".into()
                 }

--- a/verilator/src/build_library.rs
+++ b/verilator/src/build_library.rs
@@ -14,11 +14,11 @@
 use std::{fmt::Write, fs, process::Command};
 
 use camino::{Utf8Path, Utf8PathBuf};
-use snafu::{Whatever, prelude::*};
+use snafu::{prelude::*, Whatever};
 
 use crate::{
-    PortDirection, VerilatedModelConfig, VerilatorRuntimeOptions,
-    dpi::DpiFunction,
+    dpi::DpiFunction, PortDirection, VerilatedModelConfig,
+    VerilatorRuntimeOptions,
 };
 
 fn build_ffi_for_tracing(
@@ -142,8 +142,8 @@ extern "C" {{
                 lsb,
                 if width > 64 {
                     format!(", {}", width.div_ceil(32)) // words are 32 bits
-                // according to header
-                // file
+                                                        // according to header
+                                                        // file
                 } else {
                     "".into()
                 }
@@ -432,7 +432,7 @@ pub fn build_library(
     let mut verilator_command = Command::new(&options.verilator_executable);
     verilator_command
         .args(["--cc", "-sv", "-j", "0", "--build"])
-        .args(["-CFLAGS", "-shared -fpic"])
+        .args(["-CFLAGS", "-shared -fpic -std=c++17"])
         .args(["--lib-create", &library_name])
         .args(["--Mdir", verilator_artifact_directory.as_str()])
         .args(["--top-module", top_module])

--- a/verilator/src/build_library.rs
+++ b/verilator/src/build_library.rs
@@ -429,10 +429,26 @@ pub fn build_library(
     // bug in verilator#5226 means the directory must be relative to -Mdir
     let ffi_wrappers = Utf8Path::new("../ffi/ffi.cpp");
 
+    let mut cflags = "-shared -fpic".to_string();
+    if let Some(cxx_standard) = config.cxx_standard {
+        cflags += format!(
+            " -std={}",
+            match cxx_standard {
+                crate::CxxStandard::Cxx98 => "c++98",
+                crate::CxxStandard::Cxx11 => "c++11",
+                crate::CxxStandard::Cxx14 => "c++14",
+                crate::CxxStandard::Cxx17 => "c++17",
+                crate::CxxStandard::Cxx20 => "c++20",
+                crate::CxxStandard::Cxx23 => "c++23",
+                crate::CxxStandard::Cxx26 => "c++26",
+            }
+        );
+    }
+
     let mut verilator_command = Command::new(&options.verilator_executable);
     verilator_command
         .args(["--cc", "-sv", "-j", "0", "--build"])
-        .args(["-CFLAGS", "-shared -fpic -std=c++17"])
+        .args(["-CFLAGS", &cflags])
         .args(["--lib-create", &library_name])
         .args(["--Mdir", verilator_artifact_directory.as_str()])
         .args(["--top-module", top_module])

--- a/verilator/src/build_library.rs
+++ b/verilator/src/build_library.rs
@@ -431,18 +431,16 @@ pub fn build_library(
 
     let mut cflags = "-shared -fpic".to_string();
     if let Some(cxx_standard) = config.cxx_standard {
-        cflags += format!(
-            " -std={}",
-            match cxx_standard {
-                crate::CxxStandard::Cxx98 => "c++98",
-                crate::CxxStandard::Cxx11 => "c++11",
-                crate::CxxStandard::Cxx14 => "c++14",
-                crate::CxxStandard::Cxx17 => "c++17",
-                crate::CxxStandard::Cxx20 => "c++20",
-                crate::CxxStandard::Cxx23 => "c++23",
-                crate::CxxStandard::Cxx26 => "c++26",
-            }
-        );
+        cflags += " -std=";
+        cflags += match cxx_standard {
+            crate::CxxStandard::Cxx98 => "c++98",
+            crate::CxxStandard::Cxx11 => "c++11",
+            crate::CxxStandard::Cxx14 => "c++14",
+            crate::CxxStandard::Cxx17 => "c++17",
+            crate::CxxStandard::Cxx20 => "c++20",
+            crate::CxxStandard::Cxx23 => "c++23",
+            crate::CxxStandard::Cxx26 => "c++26",
+        };
     }
 
     let mut verilator_command = Command::new(&options.verilator_executable);

--- a/verilator/src/lib.rs
+++ b/verilator/src/lib.rs
@@ -87,7 +87,7 @@ impl fmt::Display for PortDirection {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CxxStandard {
     Cxx98,
     Cxx11,

--- a/verilator/src/lib.rs
+++ b/verilator/src/lib.rs
@@ -14,7 +14,7 @@
 
 use std::{
     cell::RefCell,
-    collections::{HashMap, hash_map::Entry},
+    collections::{hash_map::Entry, HashMap},
     ffi::{self, OsString},
     fmt, fs,
     hash::{self, Hash, Hasher},
@@ -32,7 +32,7 @@ use dpi::DpiFunction;
 use dynamic::DynamicVerilatedModel;
 use libloading::Library;
 use owo_colors::OwoColorize;
-use snafu::{ResultExt, Whatever, whatever};
+use snafu::{whatever, ResultExt, Whatever};
 
 mod build_library;
 pub mod dpi;
@@ -87,8 +87,19 @@ impl fmt::Display for PortDirection {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum CxxStandard {
+    Cxx98,
+    Cxx11,
+    Cxx14,
+    Cxx17,
+    Cxx20,
+    Cxx23,
+    Cxx26,
+}
+
 /// Configuration for a particular [`VerilatedModel`].
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VerilatedModelConfig {
     /// If `None`, there will be no optimization. If a value from `0` to `3`
     /// inclusive, the flag `-O<level>` will be passed. Enabling will slow
@@ -101,6 +112,20 @@ pub struct VerilatedModelConfig {
 
     /// Whether this model should be compiled with tracing support.
     pub enable_tracing: bool,
+
+    /// Optionally specify the C++ standard used by Verilator.
+    pub cxx_standard: Option<CxxStandard>,
+}
+
+impl Default for VerilatedModelConfig {
+    fn default() -> Self {
+        Self {
+            verilator_optimization: Default::default(),
+            ignored_warnings: Default::default(),
+            enable_tracing: Default::default(),
+            cxx_standard: Some(CxxStandard::Cxx14),
+        }
+    }
 }
 
 /// You should not implement this `trait` manually. Instead, use a procedural

--- a/verilator/src/lib.rs
+++ b/verilator/src/lib.rs
@@ -14,7 +14,7 @@
 
 use std::{
     cell::RefCell,
-    collections::{hash_map::Entry, HashMap},
+    collections::{HashMap, hash_map::Entry},
     ffi::{self, OsString},
     fmt, fs,
     hash::{self, Hash, Hasher},
@@ -32,7 +32,7 @@ use dpi::DpiFunction;
 use dynamic::DynamicVerilatedModel;
 use libloading::Library;
 use owo_colors::OwoColorize;
-use snafu::{whatever, ResultExt, Whatever};
+use snafu::{ResultExt, Whatever, whatever};
 
 mod build_library;
 pub mod dpi;

--- a/verilator/src/lib.rs
+++ b/verilator/src/lib.rs
@@ -87,6 +87,8 @@ impl fmt::Display for PortDirection {
     }
 }
 
+/// Based off of the [C++ standards supported by GCC](https://gcc.gnu.org/projects/cxx-status.html) as
+/// of June 6th, 2025.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CxxStandard {
     Cxx98,


### PR DESCRIPTION
```
/opt/homebrew/Cellar/verilator/5.036/share/verilator/include/verilatedos.h:283:3: error: "Verilator requires a C++14 or newer compiler"
  283 | # error "Verilator requires a C++14 or newer compiler"
      |   ^
```