### PR TITLE
fix clock port of verilog macro

### DIFF
--- a/language-support/verilog-macro-builder/src/lib.rs
+++ b/language-support/verilog-macro-builder/src/lib.rs
@@ -173,9 +173,9 @@ pub fn build_verilated_struct(
                     if clock_port.value().as_str() == port_name {
                         other_impl.push(quote! {
                             pub fn tick(&mut self) {
-                                self.#port_name = 1 as _;
+                                self.#port_name_ident = 1 as _;
                                 self.eval();
-                                self.#port_name = 0 as _;
+                                self.#port_name_ident = 0 as _;
                                 self.eval();
                             }
                         });


### PR DESCRIPTION
Fixed proc-macro `verilog`. This makes users be able to generate `tick` function with `#[verilog(src="test.sv",name="test",clock="clock")]`