### PR TITLE
fix(deps): Cut down on compile times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,13 +509,9 @@ name = "marlin"
 version = "0.7.1"
 dependencies = [
  "marlin-spade",
- "marlin-spade-macro",
  "marlin-verilator",
  "marlin-verilog",
- "marlin-verilog-macro",
- "marlin-verilog-macro-builder",
  "marlin-veryl",
- "marlin-veryl-macro",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [workspace]
 resolver = "3"
 members = [
-  "verilator",
-  "language-support/verilog",
-  "language-support/verilog-macro",
-  "language-support/verilog-macro-builder",
-  "language-support/spade",
-  "language-support/spade-macro",
-  "language-support/veryl",
-  "language-support/veryl-macro",
-  "examples/verilog-project",
-  "examples/spade-project",
-  "examples/veryl_project",
+    "verilator",
+    "language-support/verilog",
+    "language-support/verilog-macro",
+    "language-support/verilog-macro-builder",
+    "language-support/spade",
+    "language-support/spade-macro",
+    "language-support/veryl",
+    "language-support/veryl-macro",
+    "examples/verilog-project",
+    "examples/spade-project",
+    "examples/veryl_project",
 ]
 
 [workspace.package]
@@ -78,16 +78,12 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-verilog = []
-spade = []
-veryl = []
+verilog = ["dep:marlin-verilog"]
+spade = ["dep:marlin-spade"]
+veryl = ["dep:marlin-veryl"]
 
 [dependencies]
 marlin-verilator.workspace = true
-marlin-verilog.workspace = true
-marlin-verilog-macro.workspace = true
-marlin-verilog-macro-builder.workspace = true
-marlin-spade.workspace = true
-marlin-spade-macro.workspace = true
-marlin-veryl.workspace = true
-marlin-veryl-macro.workspace = true
+marlin-verilog = { workspace = true, optional = true }
+marlin-spade = { workspace = true, optional = true }
+marlin-veryl = { workspace = true, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [workspace]
 resolver = "3"
 members = [
-    "verilator",
-    "language-support/verilog",
-    "language-support/verilog-macro",
-    "language-support/verilog-macro-builder",
-    "language-support/spade",
-    "language-support/spade-macro",
-    "language-support/veryl",
-    "language-support/veryl-macro",
-    "examples/verilog-project",
-    "examples/spade-project",
-    "examples/veryl_project",
+  "verilator",
+  "language-support/verilog",
+  "language-support/verilog-macro",
+  "language-support/verilog-macro-builder",
+  "language-support/spade",
+  "language-support/spade-macro",
+  "language-support/veryl",
+  "language-support/veryl-macro",
+  "examples/verilog-project",
+  "examples/spade-project",
+  "examples/veryl_project",
 ]
 
 [workspace.package]


### PR DESCRIPTION
In the original code, even if no features were enabled, code for all language support and its dependencies would be built, resulting in a significant waste of build time and space.

This PR ensures that only the languages enabled by the user are actually built. For example, for users who only use verilog, the size of the `target` directory after a clean `cargo build` reduces from `~2.3GB` to only `~400MB`.