### PR TITLE
fix generating tick function when clock port is specified

### DIFF
--- a/language-support/verilog-macro-builder/src/lib.rs
+++ b/language-support/verilog-macro-builder/src/lib.rs
@@ -231,9 +231,9 @@ pub fn build_verilated_struct(
                     if clock_port.value().as_str() == port_name {
                         other_impl.push(quote! {
                             pub fn tick(&mut self) {
-                                self.#port_name = 1 as _;
+                                self.#port_name_ident = 1 as _;
                                 self.eval();
-                                self.#port_name = 0 as _;
+                                self.#port_name_ident = 0 as _;
                                 self.eval();
                             }
                         });


### PR DESCRIPTION
Currently it ends up generating

```rust
self."clk" = 1 as _;
```

instead of 

```rust
self.clk = 1 as _;
```