### PR TITLE
feat(verilator): Add preprocessor defines support

### DIFF
--- a/examples/verilog-project/src/defines.sv
+++ b/examples/verilog-project/src/defines.sv
@@ -1,0 +1,10 @@
+module defines_main(
+    input[31:0] data_in,
+    output[31:0] data_out
+);
+`ifdef INVERT_OUTPUT
+    assign data_out = ~data_in;
+`else
+    assign data_out = data_in;
+`endif
+endmodule

--- a/examples/verilog-project/src/lib.rs
+++ b/examples/verilog-project/src/lib.rs
@@ -26,6 +26,9 @@ pub struct DpiMain;
 #[verilog(src = "src/more_dpi.sv", name = "dpi_main")]
 pub struct MoreDpiMain;
 
+#[verilog(src = "src/defines.sv", name = "defines_main")]
+pub struct DefinesMain;
+
 pub mod enclosed {
     use marlin::verilog::prelude::*;
 

--- a/examples/verilog-project/tests/simple_test.rs
+++ b/examples/verilog-project/tests/simple_test.rs
@@ -56,3 +56,40 @@ test!(first_test);
 test!(second_test);
 test!(third_test);
 test!(fourth_test);
+
+#[test]
+#[snafu::report]
+fn test_preprocessor_defines() -> Result<(), Whatever> {
+    use example_verilog_project::DefinesMain;
+
+    let runtime = VerilatorRuntime::new(
+        "artifacts".into(),
+        &["src/defines.sv".as_ref()],
+        &[],
+        [],
+        VerilatorRuntimeOptions::default(),
+    )?;
+
+    let mut dut = runtime.create_model_simple::<DefinesMain>()?;
+    dut.data_in = 0xDEAD_BEEF;
+    dut.eval();
+    assert_eq!(dut.data_out, 0xDEAD_BEEF);
+
+    let runtime = VerilatorRuntime::new(
+        "artifacts".into(),
+        &["src/defines.sv".as_ref()],
+        &[],
+        [],
+        VerilatorRuntimeOptions {
+            defines: vec!["INVERT_OUTPUT".into()],
+            ..Default::default()
+        },
+    )?;
+
+    let mut dut = runtime.create_model_simple::<DefinesMain>()?;
+    dut.data_in = 0xDEAD_BEEF;
+    dut.eval();
+    assert_eq!(dut.data_out, !0xDEAD_BEEF);
+
+    Ok(())
+}

--- a/verilator/src/build_library.rs
+++ b/verilator/src/build_library.rs
@@ -451,6 +451,9 @@ pub fn build_library(
     for include_directory in include_directories {
         verilator_command.arg(format!("-I{include_directory}"));
     }
+    for define in &options.defines {
+        verilator_command.arg(format!("+define+{define}"));
+    }
     if let Some(dpi_file) = dpi_file {
         verilator_command.arg(dpi_file);
     }

--- a/verilator/src/lib.rs
+++ b/verilator/src/lib.rs
@@ -248,6 +248,10 @@ pub struct VerilatorRuntimeOptions {
 
     /// Whether to use the log crate.
     pub log: bool,
+
+    /// Preprocessor defines to pass to Verilator (e.g., `["SIMULATION", "DEBUG"]`
+    /// becomes `+define+SIMULATION +define+DEBUG`).
+    pub defines: Vec<String>,
 }
 
 impl Default for VerilatorRuntimeOptions {
@@ -256,6 +260,7 @@ impl Default for VerilatorRuntimeOptions {
             verilator_executable: "verilator".into(),
             force_verilator_rebuild: false,
             log: false,
+            defines: Vec::new(),
         }
     }
 }
@@ -609,6 +614,7 @@ impl VerilatorRuntime {
         let mut hasher = hash::DefaultHasher::new();
         ports.hash(&mut hasher);
         config.hash(&mut hasher);
+        self.options.defines.hash(&mut hasher);
         let library_key = LibraryArenaKey {
             name: name.to_owned(),
             source_path: source_path.to_owned(),


### PR DESCRIPTION
Adds `defines: Vec<String>` to `VerilatorRuntimeOptions` for passing `+define+` args to Verilator.

Defines are included in the library cache hash so different configurations get separate builds.

Needed for cachanova/mux-tape.