### PR TITLE
fix(verilator): use pointer types for wide port FFI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 target/
-**/artifacts/
-**/artifacts2/
-**/artifacts3/
+**/artifacts*/
 docs/
 version.txt
 *.vcd

--- a/examples/verilog-project/src/lib.rs
+++ b/examples/verilog-project/src/lib.rs
@@ -20,6 +20,12 @@ pub struct Main;
 #[verilog(src = "src/wide_main.sv", name = "wide_main")]
 pub struct WideMain;
 
+#[verilog(src = "src/very_wide_main.sv", name = "very_wide_main")]
+pub struct VeryWideMain;
+
+#[verilog(src = "src/very_wide_registered.sv", name = "very_wide_registered")]
+pub struct VeryWideRegistered;
+
 #[verilog(src = "src/dpi.sv", name = "dpi_main")]
 pub struct DpiMain;
 

--- a/examples/verilog-project/src/very_wide_main.sv
+++ b/examples/verilog-project/src/very_wide_main.sv
@@ -1,0 +1,6 @@
+module very_wide_main(
+    input[199:0] very_wide_input,
+    output[199:0] very_wide_output
+);
+    assign very_wide_output = very_wide_input;
+endmodule

--- a/examples/verilog-project/src/very_wide_registered.sv
+++ b/examples/verilog-project/src/very_wide_registered.sv
@@ -1,0 +1,9 @@
+module very_wide_registered(
+    input clk,
+    input[199:0] very_wide_input,
+    output reg [199:0] very_wide_output
+);
+    always @(posedge clk) begin
+        very_wide_output <= very_wide_input;
+    end
+endmodule

--- a/examples/verilog-project/tests/very_wide_support.rs
+++ b/examples/verilog-project/tests/very_wide_support.rs
@@ -1,0 +1,137 @@
+// Copyright (C) 2024 Ethan Uppal.
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3 of the License only.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use example_verilog_project::{VeryWideMain, VeryWideRegistered};
+use marlin::verilator::{
+    AsDynamicVerilatedModel, PortDirection, VerilatedModelConfig,
+    VerilatorRuntime, VerilatorRuntimeOptions, WideIn, dynamic::VerilatorValue,
+};
+use snafu::{ResultExt, Whatever};
+
+#[test]
+fn forwards_correctly_very_wide() -> Result<(), Whatever> {
+    let runtime = VerilatorRuntime::new(
+        "artifacts_very_wide".into(),
+        &["src/very_wide_main.sv".as_ref()],
+        &[],
+        [],
+        VerilatorRuntimeOptions::default_logging(),
+    )?;
+
+    let mut main = runtime.create_model_simple::<VeryWideMain>()?;
+
+    let test_input = [0xDEADBEEF_u32, 0xCAFEBABE, 0x12345678, 0x9ABCDEF0, 0x11111111, 0x22222222, 0x55];
+    main.very_wide_input = WideIn::new(test_input);
+    assert_eq!(main.very_wide_output.value(), &[0; 7]);
+    main.eval();
+    assert_eq!(main.very_wide_output.value(), &test_input);
+
+    Ok(())
+}
+
+#[test]
+fn forwards_correctly_very_wide_dynamically() -> Result<(), Whatever> {
+    let runtime = VerilatorRuntime::new(
+        "artifacts_very_wide_dyn".into(),
+        &["src/very_wide_main.sv".as_ref()],
+        &[],
+        [],
+        VerilatorRuntimeOptions::default_logging(),
+    )?;
+
+    let mut main = runtime.create_dyn_model(
+        "very_wide_main",
+        "src/very_wide_main.sv",
+        &[
+            ("very_wide_input", 199, 0, PortDirection::Input),
+            ("very_wide_output", 199, 0, PortDirection::Output),
+        ],
+        VerilatedModelConfig::default(),
+    )?;
+
+    let test_input: [u32; 7] = [0xDEADBEEF_u32, 0xCAFEBABE, 0x12345678, 0x9ABCDEF0, 0x11111111, 0x22222222, 0x55];
+    main.pin("very_wide_input", &test_input)
+        .whatever_context("pin")?;
+    assert_eq!(
+        main.read("very_wide_output").whatever_context("first read")?,
+        VerilatorValue::WDataOutP(vec![0, 0, 0, 0, 0, 0, 0])
+    );
+    main.eval();
+    assert_eq!(
+        main.read("very_wide_output").whatever_context("second read")?,
+        VerilatorValue::WDataOutP(test_input.to_vec())
+    );
+
+    Ok(())
+}
+
+#[test]
+fn forwards_correctly_very_wide_registered() -> Result<(), Whatever> {
+    let runtime = VerilatorRuntime::new(
+        "artifacts_very_wide_reg".into(),
+        &["src/very_wide_registered.sv".as_ref()],
+        &[],
+        [],
+        VerilatorRuntimeOptions::default_logging(),
+    )?;
+
+    let mut main = runtime.create_model_simple::<VeryWideRegistered>()?;
+
+    let test_input = [0xDEADBEEF_u32, 0xCAFEBABE, 0x12345678, 0x9ABCDEF0, 0x11111111, 0x22222222, 0x55];
+    main.very_wide_input = WideIn::new(test_input);
+    main.eval();
+
+    main.clk = 1;
+    main.eval();
+    assert_eq!(main.very_wide_output.value(), &test_input);
+
+    Ok(())
+}
+
+#[test]
+fn forwards_correctly_very_wide_registered_dynamically() -> Result<(), Whatever> {
+    let runtime = VerilatorRuntime::new(
+        "artifacts_very_wide_reg_dyn".into(),
+        &["src/very_wide_registered.sv".as_ref()],
+        &[],
+        [],
+        VerilatorRuntimeOptions::default_logging(),
+    )?;
+
+    let mut main = runtime.create_dyn_model(
+        "very_wide_registered",
+        "src/very_wide_registered.sv",
+        &[
+            ("clk", 0, 0, PortDirection::Input),
+            ("very_wide_input", 199, 0, PortDirection::Input),
+            ("very_wide_output", 199, 0, PortDirection::Output),
+        ],
+        VerilatedModelConfig::default(),
+    )?;
+
+    let test_input: [u32; 7] = [0xDEADBEEF_u32, 0xCAFEBABE, 0x12345678, 0x9ABCDEF0, 0x11111111, 0x22222222, 0x55];
+    main.pin("very_wide_input", &test_input)
+        .whatever_context("pin")?;
+    main.pin("clk", 0u8).whatever_context("pin clk")?;
+    main.eval();
+
+    main.pin("clk", 1u8).whatever_context("pin clk")?;
+    main.eval();
+    assert_eq!(
+        main.read("very_wide_output").whatever_context("read")?,
+        VerilatorValue::WDataOutP(test_input.to_vec())
+    );
+
+    Ok(())
+}

--- a/examples/verilog-project/tests/wide_support.rs
+++ b/examples/verilog-project/tests/wide_support.rs
@@ -67,7 +67,7 @@ fn forwards_correctly_dynamically() -> Result<(), Whatever> {
         .whatever_context("pin")?;
     assert_eq!(
         main.read("wide_output").whatever_context("first read")?,
-        VerilatorValue::NotDriven
+        VerilatorValue::WDataOutP(vec![0, 0, 0])
     );
     main.eval();
     assert_eq!(


### PR DESCRIPTION
## Fix
Wide ports (>64 bits) were using VlWide<N> struct by value in FFI, causing ABI mismatch for ports >128 bits where C++ uses hidden pointer parameters. Changed to explicit WData* pointer types for wide port FFI.

## Tests
Adds tests for 200-bit ports to verify the fix
## Breaking Change

### Dynamic API: Wide output port behavior before `eval()`

**Before:** Reading a wide output port (>64 bits) before calling `eval()` returned `VerilatorValue::NotDriven`.

**After:** Reading a wide output port before `eval()` returns `VerilatorValue::WDataOutP(vec![0, 0, ...])` with zeroed data.

**Reason:** The FFI now uses `.data()` which always returns a valid pointer to the underlying storage, rather than a potentially null pointer. This is more correct behavior since the memory is always allocated.

**Migration:** Code that pattern-matches on `NotDriven` for wide outputs will need to handle `WDataOutP` with zeroed values instead.

## Issues
Extends work from Issue #7