### PR TITLE
chore: Require `unsafe` blocks to be documented

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ marlin-spade-macro = { path = "language-support/spade-macro", version = "0.10.0"
 marlin-veryl = { path = "language-support/veryl", version = "0.10.0" }
 marlin-veryl-macro = { path = "language-support/veryl-macro", version = "0.10.0" }
 
+[workspace.lints.clippy]
+undocumented_unsafe_blocks = "forbid"
+
 [workspace.metadata.release]
 push = false
 tag = false

--- a/examples/spade-project/Cargo.toml
+++ b/examples/spade-project/Cargo.toml
@@ -14,6 +14,9 @@ snafu.workspace = true
 env_logger.workspace = true
 marlin = { path = "../../", features = ["spade"] }
 
+[lints]
+workspace = true
+
 [package.metadata.release]
 release = false
 publish = false

--- a/examples/verilog-project/Cargo.toml
+++ b/examples/verilog-project/Cargo.toml
@@ -18,6 +18,9 @@ snafu.workspace = true
 env_logger.workspace = true
 marlin = { path = "../../", features = ["verilog"] }
 
+[lints]
+workspace = true
+
 [package.metadata.release]
 release = false
 publish = false

--- a/examples/veryl_project/Cargo.toml
+++ b/examples/veryl_project/Cargo.toml
@@ -13,6 +13,9 @@ license = "GPL-3.0"
 snafu.workspace = true
 marlin = { path = "../..", features = ["veryl"] }
 
+[lints]
+workspace = true
+
 [package.metadata.release]
 release = false
 publish = false

--- a/language-support/spade-macro/Cargo.toml
+++ b/language-support/spade-macro/Cargo.toml
@@ -23,3 +23,6 @@ quote.workspace = true
 
 spade-parser.workspace = true
 spade-ast.workspace = true
+
+[lints]
+workspace = true

--- a/language-support/spade/Cargo.toml
+++ b/language-support/spade/Cargo.toml
@@ -19,3 +19,6 @@ owo-colors.workspace = true
 toml.workspace = true
 glob.workspace = true
 libloading.workspace = true
+
+[lints]
+workspace = true

--- a/language-support/verilog-macro-builder/Cargo.toml
+++ b/language-support/verilog-macro-builder/Cargo.toml
@@ -17,3 +17,6 @@ syn.workspace = true
 quote.workspace = true
 
 sv-parser.workspace = true
+
+[lints]
+workspace = true

--- a/language-support/verilog-macro/Cargo.toml
+++ b/language-support/verilog-macro/Cargo.toml
@@ -19,3 +19,6 @@ syn.workspace = true
 quote.workspace = true
 
 marlin-verilog-macro-builder.workspace = true
+
+[lints]
+workspace = true

--- a/language-support/verilog/Cargo.toml
+++ b/language-support/verilog/Cargo.toml
@@ -13,3 +13,6 @@ license.workspace = true
 marlin-verilog-macro.workspace = true
 marlin-verilator.workspace = true
 libloading.workspace = true
+
+[lints]
+workspace = true

--- a/language-support/veryl-macro/Cargo.toml
+++ b/language-support/veryl-macro/Cargo.toml
@@ -23,3 +23,6 @@ syn.workspace = true
 quote.workspace = true
 
 veryl-parser.workspace = true
+
+[lints]
+workspace = true

--- a/language-support/veryl/Cargo.toml
+++ b/language-support/veryl/Cargo.toml
@@ -19,3 +19,6 @@ log.workspace = true
 owo-colors.workspace = true
 toml.workspace = true
 libloading.workspace = true
+
+[lints]
+workspace = true

--- a/verilator/Cargo.toml
+++ b/verilator/Cargo.toml
@@ -18,3 +18,6 @@ file-guard.workspace = true
 owo-colors.workspace = true
 dashmap.workspace = true
 boxcar.workspace = true
+
+[lints]
+workspace = true


### PR DESCRIPTION
This is probably a good idea. I might also have some `// UNSAFE: todo` to look at manually (since they won't be caught).

- [ ] Check for `// UNSAFE: todo`
- [ ] Check for `unsafe` generated by proc macros
- [ ] Add safety comments to `unsafe` functions, both written and those generated by proc macros