### PR TITLE
fix: Don't attempt to generate clock or reset functions

### DIFF
--- a/book/reference/bridging-macros.md
+++ b/book/reference/bridging-macros.md
@@ -11,8 +11,4 @@ Under the Verilator backend, these take a common interface:
 - `name = "<name>"`: The name of the module.
 - `src = "<file>"`: The file where the module is defined relative to the manifest directory.
 
-Optionally, they take:
-
-- `clock = "<port>"`: The name of the clock port on the model. This generates a method called `.tick()` which performs a single clock cycle. It does NOT log to any VCDs that may be open, so consider `impl`ing your own `tick` method on the model instead if you want this behavior.
-
 See [the relevant internal documentation](../../internal/how-it-works.md) for technical explanation.

--- a/language-support/spade-macro/src/lib.rs
+++ b/language-support/spade-macro/src/lib.rs
@@ -187,8 +187,6 @@ pub fn spade(args: TokenStream, item: TokenStream) -> TokenStream {
         args.name,
         verilog_source_path,
         ports,
-        args.clock_port,
-        args.reset_port,
         item.into(),
     )
     .into()

--- a/language-support/verilog-macro-builder/src/lib.rs
+++ b/language-support/verilog-macro-builder/src/lib.rs
@@ -21,7 +21,9 @@ pub struct MacroArgs {
     pub source_path: syn::LitStr,
     pub name: syn::LitStr,
 
+    /// Deprecated; does nothing.
     pub clock_port: Option<syn::LitStr>,
+    /// Deprecated; does nothing.
     pub reset_port: Option<syn::LitStr>,
 }
 
@@ -75,8 +77,6 @@ pub fn build_verilated_struct(
     top_name: syn::LitStr,
     source_path: syn::LitStr,
     verilog_ports: Vec<(String, usize, usize, PortDirection)>,
-    clock_port: Option<syn::LitStr>,
-    reset_port: Option<syn::LitStr>,
     item: TokenStream,
 ) -> TokenStream {
     let crate_name = format_ident!("{}", macro_name);
@@ -91,8 +91,6 @@ pub fn build_verilated_struct(
 
     let mut preeval_impl = vec![];
     let mut posteval_impl = vec![];
-
-    let mut other_impl = vec![];
 
     let mut verilated_model_ports_impl = vec![];
     let mut verilated_model_init_impl = vec![];
@@ -225,23 +223,6 @@ pub fn build_verilated_struct(
                     preeval_impl.push(quote! {
                         (self.#setter)(self.model, self.#port_name_ident.as_ptr());
                     });
-                }
-
-                if let Some(clock_port) = &clock_port {
-                    if clock_port.value().as_str() == port_name {
-                        other_impl.push(quote! {
-                            pub fn tick(&mut self) {
-                                self.#port_name = 1 as _;
-                                self.eval();
-                                self.#port_name = 0 as _;
-                                self.eval();
-                            }
-                        });
-                    }
-                }
-
-                if let Some(_reset_port) = &reset_port {
-                    todo!("reset ports");
                 }
 
                 verilated_model_init_impl.push(quote! {
@@ -398,8 +379,6 @@ pub fn build_verilated_struct(
                     #crate_name::__reexports::verilator::vcd::__private::new_vcd_useless()
                 }
             }
-
-            #(#other_impl)*
         }
 
         impl<'ctx> #crate_name::__reexports::verilator::AsVerilatedModel<'ctx> for #struct_name<'ctx> {

--- a/language-support/verilog-macro/src/lib.rs
+++ b/language-support/verilog-macro/src/lib.rs
@@ -39,8 +39,6 @@ pub fn verilog(args: TokenStream, item: TokenStream) -> TokenStream {
             args.source_path.span(),
         ),
         ports,
-        args.clock_port,
-        args.reset_port,
         item.into(),
     )
     .into()

--- a/language-support/veryl-macro/src/lib.rs
+++ b/language-support/veryl-macro/src/lib.rs
@@ -296,8 +296,6 @@ pub fn veryl(args: TokenStream, item: TokenStream) -> TokenStream {
         verilog_module_name,
         verilog_source_path,
         ports,
-        args.clock_port,
-        args.reset_port,
         item.into(),
     )
     .into()


### PR DESCRIPTION
This is not breaking because no code should have relied on it anyways since it was never fully supported

Closes #184 