### PR TITLE
feat(verilator)!: Expose `eval` through `AsDynamicVerilatedModel`

### DIFF
--- a/examples/verilog-project/tests/simple_test.rs
+++ b/examples/verilog-project/tests/simple_test.rs
@@ -15,7 +15,10 @@
 use std::env;
 
 use example_verilog_project::Main;
-use marlin::verilator::{VerilatorRuntime, VerilatorRuntimeOptions};
+use marlin::{
+    verilator::{VerilatorRuntime, VerilatorRuntimeOptions},
+    verilog::prelude::*,
+};
 use snafu::Whatever;
 
 macro_rules! test {

--- a/examples/verilog-project/tests/tracing.rs
+++ b/examples/verilog-project/tests/tracing.rs
@@ -13,8 +13,11 @@
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use example_verilog_project::Main;
-use marlin::verilator::{
-    VerilatedModelConfig, VerilatorRuntime, VerilatorRuntimeOptions,
+use marlin::{
+    verilator::{
+        VerilatedModelConfig, VerilatorRuntime, VerilatorRuntimeOptions,
+    },
+    verilog::prelude::*,
 };
 use snafu::Whatever;
 

--- a/examples/verilog-project/tests/visibility_works.rs
+++ b/examples/verilog-project/tests/visibility_works.rs
@@ -15,7 +15,10 @@
 use std::env;
 
 use example_verilog_project::enclosed;
-use marlin::verilator::{VerilatorRuntime, VerilatorRuntimeOptions};
+use marlin::{
+    verilator::{VerilatorRuntime, VerilatorRuntimeOptions},
+    verilog::prelude::*,
+};
 use snafu::Whatever;
 
 #[test]

--- a/examples/veryl_project/tests/simple_test.rs
+++ b/examples/veryl_project/tests/simple_test.rs
@@ -13,7 +13,7 @@
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use example_veryl_project::Wire;
-use marlin::veryl::{VerylRuntime, VerylRuntimeOptions};
+use marlin::veryl::prelude::*;
 use snafu::Whatever;
 
 #[test]

--- a/language-support/spade/src/lib.rs
+++ b/language-support/spade/src/lib.rs
@@ -26,7 +26,7 @@ pub mod prelude {
     pub use crate as spade;
     pub use crate::{SpadeRuntime, SpadeRuntimeOptions};
     pub use marlin_spade_macro::spade;
-    pub use marlin_verilator::AsVerilatedModel;
+    pub use marlin_verilator::{AsDynamicVerilatedModel, AsVerilatedModel};
 }
 
 const SWIM_TOML: &str = "swim.toml";

--- a/language-support/verilog-macro-builder/src/lib.rs
+++ b/language-support/verilog-macro-builder/src/lib.rs
@@ -368,13 +368,6 @@ pub fn build_verilated_struct(
         }
 
         impl<'ctx> #struct_name<'ctx> {
-            #[doc = "Equivalent to the Verilator `eval` method."]
-            pub fn eval(&mut self) {
-                #(#preeval_impl)*
-                (self.eval_model)(self.model);
-                #(#posteval_impl)*
-            }
-
             pub fn open_vcd(
                 &mut self,
                 path: impl std::convert::AsRef<std::path::Path>,
@@ -452,6 +445,12 @@ pub fn build_verilated_struct(
         }
 
         impl<'ctx> #crate_name::__reexports::verilator::AsDynamicVerilatedModel<'ctx> for #struct_name<'ctx> {
+            fn eval(&mut self) {
+                #(#preeval_impl)*
+                (self.eval_model)(self.model);
+                #(#posteval_impl)*
+            }
+
             fn read(
                 &self,
                 port: impl Into<String>,

--- a/language-support/verilog/src/lib.rs
+++ b/language-support/verilog/src/lib.rs
@@ -16,6 +16,6 @@ pub use marlin_verilog_macro::dpi;
 
 pub mod prelude {
     pub use crate as verilog;
-    pub use marlin_verilator::AsVerilatedModel;
+    pub use marlin_verilator::{AsDynamicVerilatedModel, AsVerilatedModel};
     pub use marlin_verilog_macro::verilog;
 }

--- a/language-support/veryl/src/lib.rs
+++ b/language-support/veryl/src/lib.rs
@@ -23,7 +23,7 @@ pub mod __reexports {
 pub mod prelude {
     pub use crate as veryl;
     pub use crate::{VerylRuntime, VerylRuntimeOptions};
-    pub use marlin_verilator::AsVerilatedModel;
+    pub use marlin_verilator::{AsDynamicVerilatedModel, AsVerilatedModel};
     pub use marlin_veryl_macro::veryl;
 }
 

--- a/verilator/src/dynamic.rs
+++ b/verilator/src/dynamic.rs
@@ -99,6 +99,9 @@ impl<const LENGTH: usize> From<WideOut<LENGTH>> for VerilatorValue<'_> {
 
 /// Access model ports at runtime.
 pub trait AsDynamicVerilatedModel<'ctx>: 'ctx {
+    /// Equivalent to the Verilator `eval` method.
+    fn eval(&mut self);
+
     /// If `port` is a valid port name for this model, returns the current value
     /// of the port.
     fn read(
@@ -130,13 +133,6 @@ pub struct DynamicVerilatedModel<'ctx> {
     pub(crate) main: *mut ffi::c_void,
     pub(crate) eval_main: extern "C" fn(*mut ffi::c_void),
     pub(crate) library: &'ctx Library,
-}
-
-impl DynamicVerilatedModel<'_> {
-    /// Equivalent to the Verilator `eval` method.
-    pub fn eval(&mut self) {
-        (self.eval_main)(self.main);
-    }
 }
 
 /// Runtime port read/write error.
@@ -173,6 +169,10 @@ pub enum DynamicVerilatedModelError {
 }
 
 impl<'ctx> AsDynamicVerilatedModel<'ctx> for DynamicVerilatedModel<'ctx> {
+    fn eval(&mut self) {
+        (self.eval_main)(self.main);
+    }
+
     fn read(
         &self,
         port: impl Into<String>,


### PR DESCRIPTION
- Add `Release-As: 0.11.0` to squash commit because we're in prerelease
- This is technically breaking because some people might not use `prelude::*`
- This is technically a feature not a refactor because it allows for new stuff to be written