### PR TITLE
fix(verilog): Handle semver breaking update to sv-parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,9 +1398,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "sv-parser"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3cb47be895e87c45ec62a6007d5fb2f9fcc16901505d9b8ebf10c0ecc3ad55"
+checksum = "f79b1e8208e59152d004e716046dc81d58c51c9fc2936406f59a146667459052"
 dependencies = [
  "nom",
  "nom-greedyerror",
@@ -1412,18 +1412,18 @@ dependencies = [
 
 [[package]]
 name = "sv-parser-error"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f096e56219e347b9a80f81d1bd0735bb01f08fbdcd7db27af930214d11c73007"
+checksum = "4906405c210df0f38e970d4386b9cea9e90b2eee817e713c8a6cbc5e672d5590"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "sv-parser-macros"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad202093c8d708d44346defdd8a822a642382f7e25e1acd4d60886e22118be3c"
+checksum = "5fde0ec4e5b1a94dcccb97d75a06c55dc766fcd4fadff0908a8118fd39dc230b"
 dependencies = [
  "quote",
  "syn 2.0.115",
@@ -1431,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "sv-parser-parser"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9828f37b7d8300760af0f82c5f0cbfe74d4b40a59aecfc125ecfae739e143351"
+checksum = "1102d43d61c115714a5145b3822e1caf40426d202033d1a25185dfa0cb54325c"
 dependencies = [
  "nom",
  "nom-greedyerror",
@@ -1448,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "sv-parser-pp"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bb664321fb38eacb5b35b8df07cd446bf1e312e24e2c19bfbb1991883810db"
+checksum = "0bcee0f8f15313780dd25fc8c80c66aab1fde7aee791351cc0dd20e26e10c73d"
 dependencies = [
  "nom",
  "nom-greedyerror",
@@ -1461,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "sv-parser-syntaxtree"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1ef9bafa127301bfbb9aa839ecd37e5b4a9aad839af4192188a3f8d53ee274"
+checksum = "fac54467c2b9e4e13c85dba6eebdf8b5227e3420bb5a832be9643cc46d136176"
 dependencies = [
  "regex",
  "sv-parser-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ proc-macro2 = { version = "1.0.93", default-features = false }
 syn = { version = "2.0.96", features = ["full"] }
 quote = { version = "1.0.38", default-features = false }
 
-sv-parser = { version = "0.13.4", default-features = false }
+sv-parser = { version = "0.13.5", default-features = false }
 spade-parser = { version = "0.16.0", default-features = false }
 spade-ast = { version = "0.16.0", default-features = false }
 veryl-parser = { version = "0.14.2-rc.1", default-features = false }

--- a/language-support/verilog-macro-builder/src/util.rs
+++ b/language-support/verilog-macro-builder/src/util.rs
@@ -70,5 +70,8 @@ pub fn evaluate_numeric_constant_expression(
         sv::ConstantExpression::Ternary(_constant_expression_ternary) => {
             todo!("Constant ternary expressions")
         }
+        sv::ConstantExpression::Inside(_constant_expression_inside) => {
+            todo!("Constant inside expressions")
+        }
     }
 }


### PR DESCRIPTION
sv-parser made a semver breaking update when it updated from 0.13.4 to 0.13.5 in one of its deps which breaks marlin's builds. As the change is to a dependency, it is annoying to simply lock the version to the old one. marlin already doesn't support a bunch of constant expressions so I added the new one the made to that list and bump the version of sv-parser.