### PR TITLE
refactor(verilator)!: Avoid exposing `camino` in public API

### DIFF
--- a/examples/verilog-project/src/tutorial.rs
+++ b/examples/verilog-project/src/tutorial.rs
@@ -12,8 +12,10 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::path::Path;
+
 use marlin::{
-    verilator::{VerilatorRuntime, VerilatorRuntimeOptions, verilator_version},
+    verilator::{verilator_version, VerilatorRuntime, VerilatorRuntimeOptions},
     verilog::prelude::*,
 };
 use snafu::Whatever;
@@ -24,9 +26,9 @@ struct Main;
 #[snafu::report]
 fn main() -> Result<(), Whatever> {
     let runtime = VerilatorRuntime::new(
-        "artifacts".into(),
-        &["src/main.sv".as_ref()],
-        &[],
+        "artifacts",
+        &["src/main.sv"],
+        &[] as &[&Path],
         [],
         VerilatorRuntimeOptions::default()
             .allow_unsupported_verilator(Some(verilator_version!(5 020))),

--- a/examples/verilog-project/src/tutorial.rs
+++ b/examples/verilog-project/src/tutorial.rs
@@ -15,7 +15,7 @@
 use std::path::Path;
 
 use marlin::{
-    verilator::{verilator_version, VerilatorRuntime, VerilatorRuntimeOptions},
+    verilator::{VerilatorRuntime, VerilatorRuntimeOptions, verilator_version},
     verilog::prelude::*,
 };
 use snafu::Whatever;

--- a/examples/verilog-project/src/tutorial.rs
+++ b/examples/verilog-project/src/tutorial.rs
@@ -25,7 +25,7 @@ struct Main;
 
 #[snafu::report]
 fn main() -> Result<(), Whatever> {
-    let runtime = VerilatorRuntime::new(
+    let runtime = VerilatorRuntime::new2(
         "artifacts",
         &["src/main.sv"],
         &[] as &[&Path],

--- a/examples/verilog-project/tests/as_dynamic_model.rs
+++ b/examples/verilog-project/tests/as_dynamic_model.rs
@@ -24,7 +24,7 @@ use snafu::Whatever;
 #[test]
 #[snafu::report]
 fn main() -> Result<(), Whatever> {
-    let runtime = VerilatorRuntime::new(
+    let runtime = VerilatorRuntime::new2(
         "artifacts2",
         &["src/main.sv"],
         &[] as &[&Path],

--- a/examples/verilog-project/tests/as_dynamic_model.rs
+++ b/examples/verilog-project/tests/as_dynamic_model.rs
@@ -16,8 +16,8 @@ use std::path::Path;
 
 use example_verilog_project::Main;
 use marlin::verilator::{
-    verilator_version, AsDynamicVerilatedModel, VerilatorRuntime,
-    VerilatorRuntimeOptions,
+    AsDynamicVerilatedModel, VerilatorRuntime, VerilatorRuntimeOptions,
+    verilator_version,
 };
 use snafu::Whatever;
 

--- a/examples/verilog-project/tests/as_dynamic_model.rs
+++ b/examples/verilog-project/tests/as_dynamic_model.rs
@@ -12,10 +12,12 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::path::Path;
+
 use example_verilog_project::Main;
 use marlin::verilator::{
-    AsDynamicVerilatedModel, VerilatorRuntime, VerilatorRuntimeOptions,
-    verilator_version,
+    verilator_version, AsDynamicVerilatedModel, VerilatorRuntime,
+    VerilatorRuntimeOptions,
 };
 use snafu::Whatever;
 
@@ -23,9 +25,9 @@ use snafu::Whatever;
 #[snafu::report]
 fn main() -> Result<(), Whatever> {
     let runtime = VerilatorRuntime::new(
-        "artifacts2".into(),
-        &["src/main.sv".as_ref()],
-        &[],
+        "artifacts2",
+        &["src/main.sv"],
+        &[] as &[&Path],
         [],
         VerilatorRuntimeOptions::default()
             .allow_unsupported_verilator(Some(verilator_version!(5 020))),

--- a/examples/verilog-project/tests/dpi_tutorial.rs
+++ b/examples/verilog-project/tests/dpi_tutorial.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 
 use example_verilog_project::{DpiMain, MoreDpiMain};
 use marlin::{
-    verilator::{verilator_version, VerilatorRuntime, VerilatorRuntimeOptions},
+    verilator::{VerilatorRuntime, VerilatorRuntimeOptions, verilator_version},
     verilog::prelude::*,
 };
 use snafu::Whatever;

--- a/examples/verilog-project/tests/dpi_tutorial.rs
+++ b/examples/verilog-project/tests/dpi_tutorial.rs
@@ -31,7 +31,7 @@ pub extern "C" fn set_out(output: &mut i32) {
 #[test]
 #[snafu::report]
 fn main_tutorial() -> Result<(), Whatever> {
-    let runtime = VerilatorRuntime::new(
+    let runtime = VerilatorRuntime::new2(
         "artifacts",
         &["src/dpi.sv"],
         &[] as &[&Path],
@@ -69,7 +69,7 @@ pub extern "C" fn set_bool_out(output: &mut bool) {
 #[test]
 #[snafu::report]
 fn other_test() -> Result<(), Whatever> {
-    let runtime = VerilatorRuntime::new(
+    let runtime = VerilatorRuntime::new2(
         "artifacts",
         &["src/more_dpi.sv"],
         &[] as &[&Path],

--- a/examples/verilog-project/tests/dpi_tutorial.rs
+++ b/examples/verilog-project/tests/dpi_tutorial.rs
@@ -12,9 +12,11 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::path::Path;
+
 use example_verilog_project::{DpiMain, MoreDpiMain};
 use marlin::{
-    verilator::{VerilatorRuntime, VerilatorRuntimeOptions, verilator_version},
+    verilator::{verilator_version, VerilatorRuntime, VerilatorRuntimeOptions},
     verilog::prelude::*,
 };
 use snafu::Whatever;
@@ -30,9 +32,9 @@ pub extern "C" fn set_out(output: &mut i32) {
 #[snafu::report]
 fn main_tutorial() -> Result<(), Whatever> {
     let runtime = VerilatorRuntime::new(
-        "artifacts".into(),
-        &["src/dpi.sv".as_ref()],
-        &[],
+        "artifacts",
+        &["src/dpi.sv"],
+        &[] as &[&Path],
         [set_out],
         VerilatorRuntimeOptions::default()
             .allow_unsupported_verilator(Some(verilator_version!(5 020))),
@@ -68,9 +70,9 @@ pub extern "C" fn set_bool_out(output: &mut bool) {
 #[snafu::report]
 fn other_test() -> Result<(), Whatever> {
     let runtime = VerilatorRuntime::new(
-        "artifacts".into(),
-        &["src/more_dpi.sv".as_ref()],
-        &[],
+        "artifacts",
+        &["src/more_dpi.sv"],
+        &[] as &[&Path],
         [set_unsigned_int_out, check_unsigned_int_out, set_bool_out],
         VerilatorRuntimeOptions::default()
             .allow_unsupported_verilator(Some(verilator_version!(5 020))),

--- a/examples/verilog-project/tests/dynamic_model_tutorial.rs
+++ b/examples/verilog-project/tests/dynamic_model_tutorial.rs
@@ -15,8 +15,8 @@
 use std::path::Path;
 
 use marlin::verilator::{
-    verilator_version, AsDynamicVerilatedModel, PortDirection,
-    VerilatedModelConfig, VerilatorRuntime, VerilatorRuntimeOptions,
+    AsDynamicVerilatedModel, PortDirection, VerilatedModelConfig,
+    VerilatorRuntime, VerilatorRuntimeOptions, verilator_version,
 };
 use snafu::Whatever;
 

--- a/examples/verilog-project/tests/dynamic_model_tutorial.rs
+++ b/examples/verilog-project/tests/dynamic_model_tutorial.rs
@@ -23,7 +23,7 @@ use snafu::Whatever;
 #[test]
 #[snafu::report]
 fn main() -> Result<(), Whatever> {
-    let runtime = VerilatorRuntime::new(
+    let runtime = VerilatorRuntime::new2(
         "artifacts2",
         &["src/main.sv"],
         &[] as &[&Path],

--- a/examples/verilog-project/tests/dynamic_model_tutorial.rs
+++ b/examples/verilog-project/tests/dynamic_model_tutorial.rs
@@ -12,9 +12,11 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::path::Path;
+
 use marlin::verilator::{
-    AsDynamicVerilatedModel, PortDirection, VerilatedModelConfig,
-    VerilatorRuntime, VerilatorRuntimeOptions, verilator_version,
+    verilator_version, AsDynamicVerilatedModel, PortDirection,
+    VerilatedModelConfig, VerilatorRuntime, VerilatorRuntimeOptions,
 };
 use snafu::Whatever;
 
@@ -22,9 +24,9 @@ use snafu::Whatever;
 #[snafu::report]
 fn main() -> Result<(), Whatever> {
     let runtime = VerilatorRuntime::new(
-        "artifacts2".into(),
-        &["src/main.sv".as_ref()],
-        &[],
+        "artifacts2",
+        &["src/main.sv"],
+        &[] as &[&Path],
         [],
         VerilatorRuntimeOptions::default()
             .allow_unsupported_verilator(Some(verilator_version!(5 020))),

--- a/examples/verilog-project/tests/simple_test.rs
+++ b/examples/verilog-project/tests/simple_test.rs
@@ -14,7 +14,7 @@
 
 use example_verilog_project::Main;
 use marlin::{
-    verilator::{verilator_version, VerilatorRuntime, VerilatorRuntimeOptions},
+    verilator::{VerilatorRuntime, VerilatorRuntimeOptions, verilator_version},
     verilog::prelude::*,
 };
 use snafu::Whatever;

--- a/examples/verilog-project/tests/simple_test.rs
+++ b/examples/verilog-project/tests/simple_test.rs
@@ -24,7 +24,7 @@ macro_rules! test {
         #[test]
         #[snafu::report]
         fn $name() -> Result<(), Whatever> {
-            let runtime = VerilatorRuntime::new(
+            let runtime = VerilatorRuntime::new2(
                 "artifacts",
                 &["src/main.sv"],
                 &[] as &[&std::path::Path],

--- a/examples/verilog-project/tests/simple_test.rs
+++ b/examples/verilog-project/tests/simple_test.rs
@@ -14,7 +14,7 @@
 
 use example_verilog_project::Main;
 use marlin::{
-    verilator::{VerilatorRuntime, VerilatorRuntimeOptions, verilator_version},
+    verilator::{verilator_version, VerilatorRuntime, VerilatorRuntimeOptions},
     verilog::prelude::*,
 };
 use snafu::Whatever;
@@ -25,9 +25,9 @@ macro_rules! test {
         #[snafu::report]
         fn $name() -> Result<(), Whatever> {
             let runtime = VerilatorRuntime::new(
-                "artifacts".into(),
-                &["src/main.sv".as_ref()],
-                &[],
+                "artifacts",
+                &["src/main.sv"],
+                &[] as &[&std::path::Path],
                 [],
                 VerilatorRuntimeOptions::default()
                     .allow_unsupported_verilator(Some(verilator_version!(5 020))),

--- a/examples/verilog-project/tests/tracing.rs
+++ b/examples/verilog-project/tests/tracing.rs
@@ -17,8 +17,8 @@ use std::path::Path;
 use example_verilog_project::Main;
 use marlin::{
     verilator::{
-        tracing::Waveform, verilator_version, VerilatedModelConfig,
-        VerilatorRuntime, VerilatorRuntimeOptions,
+        VerilatedModelConfig, VerilatorRuntime, VerilatorRuntimeOptions,
+        tracing::Waveform, verilator_version,
     },
     verilog::prelude::*,
 };

--- a/examples/verilog-project/tests/tracing.rs
+++ b/examples/verilog-project/tests/tracing.rs
@@ -27,7 +27,7 @@ use snafu::Whatever;
 #[test]
 #[snafu::report]
 fn forwards_correctly_vcd() -> Result<(), Whatever> {
-    let runtime = VerilatorRuntime::new(
+    let runtime = VerilatorRuntime::new2(
         "artifacts",
         &["src/main.sv"],
         &[] as &[&Path],
@@ -60,7 +60,7 @@ fn forwards_correctly_vcd() -> Result<(), Whatever> {
 #[test]
 #[snafu::report]
 fn forwards_correctly_fst() -> Result<(), Whatever> {
-    let runtime = VerilatorRuntime::new(
+    let runtime = VerilatorRuntime::new2(
         "artifacts",
         &["src/main.sv"],
         &[] as &[&Path],

--- a/examples/verilog-project/tests/tracing.rs
+++ b/examples/verilog-project/tests/tracing.rs
@@ -12,11 +12,13 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::path::Path;
+
 use example_verilog_project::Main;
 use marlin::{
     verilator::{
-        VerilatedModelConfig, VerilatorRuntime, VerilatorRuntimeOptions,
-        tracing::Waveform, verilator_version,
+        tracing::Waveform, verilator_version, VerilatedModelConfig,
+        VerilatorRuntime, VerilatorRuntimeOptions,
     },
     verilog::prelude::*,
 };
@@ -26,9 +28,9 @@ use snafu::Whatever;
 #[snafu::report]
 fn forwards_correctly_vcd() -> Result<(), Whatever> {
     let runtime = VerilatorRuntime::new(
-        "artifacts".into(),
-        &["src/main.sv".as_ref()],
-        &[],
+        "artifacts",
+        &["src/main.sv"],
+        &[] as &[&Path],
         [],
         VerilatorRuntimeOptions::default()
             .allow_unsupported_verilator(Some(verilator_version!(5 020))),
@@ -59,9 +61,9 @@ fn forwards_correctly_vcd() -> Result<(), Whatever> {
 #[snafu::report]
 fn forwards_correctly_fst() -> Result<(), Whatever> {
     let runtime = VerilatorRuntime::new(
-        "artifacts".into(),
-        &["src/main.sv".as_ref()],
-        &[],
+        "artifacts",
+        &["src/main.sv"],
+        &[] as &[&Path],
         [],
         VerilatorRuntimeOptions::default()
             .allow_unsupported_verilator(Some(verilator_version!(5 020))),

--- a/examples/verilog-project/tests/visibility_works.rs
+++ b/examples/verilog-project/tests/visibility_works.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 
 use example_verilog_project::enclosed;
 use marlin::{
-    verilator::{verilator_version, VerilatorRuntime, VerilatorRuntimeOptions},
+    verilator::{VerilatorRuntime, VerilatorRuntimeOptions, verilator_version},
     verilog::prelude::*,
 };
 use snafu::Whatever;

--- a/examples/verilog-project/tests/visibility_works.rs
+++ b/examples/verilog-project/tests/visibility_works.rs
@@ -24,7 +24,7 @@ use snafu::Whatever;
 #[test]
 #[snafu::report]
 fn main() -> Result<(), Whatever> {
-    let runtime = VerilatorRuntime::new(
+    let runtime = VerilatorRuntime::new2(
         "artifacts3",
         &["src/main.sv"],
         &[] as &[&Path],

--- a/examples/verilog-project/tests/visibility_works.rs
+++ b/examples/verilog-project/tests/visibility_works.rs
@@ -12,9 +12,11 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::path::Path;
+
 use example_verilog_project::enclosed;
 use marlin::{
-    verilator::{VerilatorRuntime, VerilatorRuntimeOptions, verilator_version},
+    verilator::{verilator_version, VerilatorRuntime, VerilatorRuntimeOptions},
     verilog::prelude::*,
 };
 use snafu::Whatever;
@@ -23,9 +25,9 @@ use snafu::Whatever;
 #[snafu::report]
 fn main() -> Result<(), Whatever> {
     let runtime = VerilatorRuntime::new(
-        "artifacts3".into(),
-        &["src/main.sv".as_ref()],
-        &[],
+        "artifacts3",
+        &["src/main.sv"],
+        &[] as &[&Path],
         [],
         VerilatorRuntimeOptions::default()
             .allow_unsupported_verilator(Some(verilator_version!(5 020))),

--- a/examples/verilog-project/tests/wide_support.rs
+++ b/examples/verilog-project/tests/wide_support.rs
@@ -16,8 +16,8 @@ use std::path::Path;
 
 use example_verilog_project::WideMain;
 use marlin::verilator::{
-    verilator_version, AsDynamicVerilatedModel, PortDirection,
-    VerilatedModelConfig, VerilatorRuntime, VerilatorRuntimeOptions, WideIn,
+    AsDynamicVerilatedModel, PortDirection, VerilatedModelConfig,
+    VerilatorRuntime, VerilatorRuntimeOptions, WideIn, verilator_version,
 };
 use snafu::Whatever;
 

--- a/examples/verilog-project/tests/wide_support.rs
+++ b/examples/verilog-project/tests/wide_support.rs
@@ -24,7 +24,7 @@ use snafu::Whatever;
 #[test]
 #[snafu::report]
 fn all_wide_mains_forward_correctly() -> Result<(), Whatever> {
-    let runtime = VerilatorRuntime::new(
+    let runtime = VerilatorRuntime::new2(
         "artifacts2",
         &["src/wide_main.sv"],
         &[] as &[&Path],
@@ -78,7 +78,7 @@ fn all_wide_mains_forward_correctly() -> Result<(), Whatever> {
 #[test]
 #[snafu::report]
 fn wide_main_forwards_correctly_dynamically() -> Result<(), Whatever> {
-    let runtime = VerilatorRuntime::new(
+    let runtime = VerilatorRuntime::new2(
         "artifacts2",
         &["src/wide_main.sv"],
         &[] as &[&Path],
@@ -114,7 +114,7 @@ fn wide_main_forwards_correctly_dynamically() -> Result<(), Whatever> {
 #[test]
 #[snafu::report]
 fn wide_main4_forwards_correctly_dynamically() -> Result<(), Whatever> {
-    let runtime = VerilatorRuntime::new(
+    let runtime = VerilatorRuntime::new2(
         "artifacts2",
         &["src/wide_main.sv"],
         &[] as &[&Path],

--- a/examples/verilog-project/tests/wide_support.rs
+++ b/examples/verilog-project/tests/wide_support.rs
@@ -12,10 +12,12 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::path::Path;
+
 use example_verilog_project::WideMain;
 use marlin::verilator::{
-    AsDynamicVerilatedModel, PortDirection, VerilatedModelConfig,
-    VerilatorRuntime, VerilatorRuntimeOptions, WideIn, verilator_version,
+    verilator_version, AsDynamicVerilatedModel, PortDirection,
+    VerilatedModelConfig, VerilatorRuntime, VerilatorRuntimeOptions, WideIn,
 };
 use snafu::Whatever;
 
@@ -23,9 +25,9 @@ use snafu::Whatever;
 #[snafu::report]
 fn all_wide_mains_forward_correctly() -> Result<(), Whatever> {
     let runtime = VerilatorRuntime::new(
-        "artifacts2".into(),
-        &["src/wide_main.sv".as_ref()],
-        &[],
+        "artifacts2",
+        &["src/wide_main.sv"],
+        &[] as &[&Path],
         [],
         VerilatorRuntimeOptions::default()
             .allow_unsupported_verilator(Some(verilator_version!(5 020))),
@@ -77,9 +79,9 @@ fn all_wide_mains_forward_correctly() -> Result<(), Whatever> {
 #[snafu::report]
 fn wide_main_forwards_correctly_dynamically() -> Result<(), Whatever> {
     let runtime = VerilatorRuntime::new(
-        "artifacts2".into(),
-        &["src/wide_main.sv".as_ref()],
-        &[],
+        "artifacts2",
+        &["src/wide_main.sv"],
+        &[] as &[&Path],
         [],
         VerilatorRuntimeOptions::default()
             .allow_unsupported_verilator(Some(verilator_version!(5 020))),
@@ -113,9 +115,9 @@ fn wide_main_forwards_correctly_dynamically() -> Result<(), Whatever> {
 #[snafu::report]
 fn wide_main4_forwards_correctly_dynamically() -> Result<(), Whatever> {
     let runtime = VerilatorRuntime::new(
-        "artifacts2".into(),
-        &["src/wide_main.sv".as_ref()],
-        &[],
+        "artifacts2",
+        &["src/wide_main.sv"],
+        &[] as &[&Path],
         [],
         VerilatorRuntimeOptions::default()
             .allow_unsupported_verilator(Some(verilator_version!(5 020))),

--- a/language-support/spade/src/lib.rs
+++ b/language-support/spade/src/lib.rs
@@ -10,11 +10,11 @@ use std::{env::current_dir, ffi::OsString, fs, process::Command};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use marlin_verilator::{
-    AsVerilatedModel, VerilatedModelConfig, VerilatorRuntime,
-    VerilatorRuntimeOptions, eprintln_nocapture,
+    eprintln_nocapture, AsVerilatedModel, VerilatedModelConfig,
+    VerilatorRuntime, VerilatorRuntimeOptions,
 };
 use owo_colors::OwoColorize;
-use snafu::{OptionExt, ResultExt, Whatever, whatever};
+use snafu::{whatever, OptionExt, ResultExt, Whatever};
 
 #[doc(hidden)]
 pub mod __reexports {
@@ -27,7 +27,7 @@ pub mod prelude {
     pub use crate::{SpadeRuntime, SpadeRuntimeOptions};
     pub use marlin_spade_macro::spade;
     pub use marlin_verilator::{
-        AsDynamicVerilatedModel, AsVerilatedModel, tracing::OpenTrace,
+        tracing::OpenTrace, AsDynamicVerilatedModel, AsVerilatedModel,
     };
 }
 
@@ -223,9 +223,9 @@ impl SpadeRuntime {
         }
 
         Ok(Self {
-            verilator_runtime: VerilatorRuntime::new(
+            verilator_runtime: VerilatorRuntime::new2(
                 // https://discord.com/channels/962274366043873301/962296357018828822/1332274022280466503
-                &swim_project_path.join("build/thirdparty/marlin"),
+                swim_project_path.join("build/thirdparty/marlin"),
                 &source_files,
                 &include_files,
                 [],

--- a/language-support/spade/src/lib.rs
+++ b/language-support/spade/src/lib.rs
@@ -10,11 +10,11 @@ use std::{env::current_dir, ffi::OsString, fs, process::Command};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use marlin_verilator::{
-    eprintln_nocapture, AsVerilatedModel, VerilatedModelConfig,
-    VerilatorRuntime, VerilatorRuntimeOptions,
+    AsVerilatedModel, VerilatedModelConfig, VerilatorRuntime,
+    VerilatorRuntimeOptions, eprintln_nocapture,
 };
 use owo_colors::OwoColorize;
-use snafu::{whatever, OptionExt, ResultExt, Whatever};
+use snafu::{OptionExt, ResultExt, Whatever, whatever};
 
 #[doc(hidden)]
 pub mod __reexports {
@@ -27,7 +27,7 @@ pub mod prelude {
     pub use crate::{SpadeRuntime, SpadeRuntimeOptions};
     pub use marlin_spade_macro::spade;
     pub use marlin_verilator::{
-        tracing::OpenTrace, AsDynamicVerilatedModel, AsVerilatedModel,
+        AsDynamicVerilatedModel, AsVerilatedModel, tracing::OpenTrace,
     };
 }
 

--- a/language-support/veryl/src/lib.rs
+++ b/language-support/veryl/src/lib.rs
@@ -8,11 +8,11 @@ use std::{env::current_dir, ffi::OsString, fs, process::Command};
 
 use camino::Utf8PathBuf;
 use marlin_verilator::{
-    AsVerilatedModel, VerilatorRuntime, VerilatorRuntimeOptions,
-    eprintln_nocapture,
+    eprintln_nocapture, AsVerilatedModel, VerilatorRuntime,
+    VerilatorRuntimeOptions,
 };
 use owo_colors::OwoColorize;
-use snafu::{OptionExt, ResultExt, Whatever, whatever};
+use snafu::{whatever, OptionExt, ResultExt, Whatever};
 
 #[doc(hidden)]
 pub mod __reexports {
@@ -24,7 +24,7 @@ pub mod prelude {
     pub use crate as veryl;
     pub use crate::{VerylRuntime, VerylRuntimeOptions};
     pub use marlin_verilator::{
-        AsDynamicVerilatedModel, AsVerilatedModel, tracing::OpenTrace,
+        tracing::OpenTrace, AsDynamicVerilatedModel, AsVerilatedModel,
     };
     pub use marlin_veryl_macro::veryl;
 }
@@ -170,9 +170,9 @@ impl VerylRuntime {
 
         Ok(Self {
             verilator_runtime: VerilatorRuntime::new(
-                &veryl_project_path.join("dependencies/whatever"),
+                veryl_project_path.join("dependencies/whatever"),
                 &verilog_source_files_ref,
-                &[],
+                &[] as &[Utf8PathBuf],
                 [],
                 options.verilator_options,
             )?,

--- a/language-support/veryl/src/lib.rs
+++ b/language-support/veryl/src/lib.rs
@@ -169,7 +169,7 @@ impl VerylRuntime {
             .collect::<Vec<_>>();
 
         Ok(Self {
-            verilator_runtime: VerilatorRuntime::new(
+            verilator_runtime: VerilatorRuntime::new2(
                 veryl_project_path.join("dependencies/whatever"),
                 &verilog_source_files_ref,
                 &[] as &[Utf8PathBuf],

--- a/language-support/veryl/src/lib.rs
+++ b/language-support/veryl/src/lib.rs
@@ -8,11 +8,11 @@ use std::{env::current_dir, ffi::OsString, fs, process::Command};
 
 use camino::Utf8PathBuf;
 use marlin_verilator::{
-    eprintln_nocapture, AsVerilatedModel, VerilatorRuntime,
-    VerilatorRuntimeOptions,
+    AsVerilatedModel, VerilatorRuntime, VerilatorRuntimeOptions,
+    eprintln_nocapture,
 };
 use owo_colors::OwoColorize;
-use snafu::{whatever, OptionExt, ResultExt, Whatever};
+use snafu::{OptionExt, ResultExt, Whatever, whatever};
 
 #[doc(hidden)]
 pub mod __reexports {
@@ -24,7 +24,7 @@ pub mod prelude {
     pub use crate as veryl;
     pub use crate::{VerylRuntime, VerylRuntimeOptions};
     pub use marlin_verilator::{
-        tracing::OpenTrace, AsDynamicVerilatedModel, AsVerilatedModel,
+        AsDynamicVerilatedModel, AsVerilatedModel, tracing::OpenTrace,
     };
     pub use marlin_veryl_macro::veryl;
 }

--- a/verilator/src/build_library.rs
+++ b/verilator/src/build_library.rs
@@ -14,18 +14,18 @@
 use std::{fmt::Write, fs, process::Command};
 
 use camino::{Utf8Path, Utf8PathBuf};
-use snafu::{prelude::*, Whatever};
+use snafu::{Whatever, prelude::*};
 
 use crate::{
-    compute_wdata_word_count_from_width_not_msb,
+    BuildTarget, PortDirection, VerilatedModelConfig, VerilatorRuntimeOptions,
+    VerilatorVersion, compute_wdata_word_count_from_width_not_msb,
     dpi::DpiFunction,
     ffi_names::{
         self, DPI_INIT_CALLBACK, TRACE_CLOSE_AND_DELETE, TRACE_DUMP,
         TRACE_EVER_ON, TRACE_FLUSH, TRACE_OPEN_NEXT,
     },
     tracing::Waveform,
-    types, verilator_version, BuildTarget, PortDirection, VerilatedModelConfig,
-    VerilatorRuntimeOptions, VerilatorVersion,
+    types, verilator_version,
 };
 
 fn build_ffi_for_tracing(

--- a/verilator/src/build_library.rs
+++ b/verilator/src/build_library.rs
@@ -14,18 +14,18 @@
 use std::{fmt::Write, fs, process::Command};
 
 use camino::{Utf8Path, Utf8PathBuf};
-use snafu::{Whatever, prelude::*};
+use snafu::{prelude::*, Whatever};
 
 use crate::{
-    BuildTarget, PortDirection, VerilatedModelConfig, VerilatorRuntimeOptions,
-    VerilatorVersion, compute_wdata_word_count_from_width_not_msb,
+    compute_wdata_word_count_from_width_not_msb,
     dpi::DpiFunction,
     ffi_names::{
         self, DPI_INIT_CALLBACK, TRACE_CLOSE_AND_DELETE, TRACE_DUMP,
         TRACE_EVER_ON, TRACE_FLUSH, TRACE_OPEN_NEXT,
     },
     tracing::Waveform,
-    types, verilator_version,
+    types, verilator_version, BuildTarget, PortDirection, VerilatedModelConfig,
+    VerilatorRuntimeOptions, VerilatorVersion,
 };
 
 fn build_ffi_for_tracing(

--- a/verilator/src/lib.rs
+++ b/verilator/src/lib.rs
@@ -16,10 +16,11 @@ use core::convert::Into;
 use std::{
     cell::RefCell,
     cmp,
-    collections::{HashMap, hash_map::Entry},
+    collections::{hash_map::Entry, HashMap},
     ffi::{self, OsStr, OsString},
     fmt, fs,
     hash::{self, Hash, Hasher},
+    path::Path,
     process::Command,
     slice,
     sync::{LazyLock, Mutex},
@@ -34,7 +35,7 @@ use dpi::DpiFunction;
 use dynamic::DynamicVerilatedModel;
 use libloading::Library;
 use owo_colors::OwoColorize;
-use snafu::{OptionExt, ResultExt, Whatever, whatever};
+use snafu::{whatever, OptionExt, ResultExt, Whatever};
 
 mod build_library;
 pub mod dpi;
@@ -528,12 +529,13 @@ impl VerilatorRuntime {
     /// Creates a new runtime for instantiating (System)Verilog modules as Rust
     /// objects.
     pub fn new(
-        artifact_directory: &Utf8Path,
-        source_files: &[&Utf8Path],
-        include_directories: &[&Utf8Path],
+        artifact_directory: impl AsRef<Path>,
+        source_files: &[impl AsRef<Path>],
+        include_directories: &[impl AsRef<Path>],
         dpi_functions: impl IntoIterator<Item = &'static dyn DpiFunction>,
         options: VerilatorRuntimeOptions,
     ) -> Result<Self, Whatever> {
+        let artifact_directory = artifact_directory.as_ref();
         let verilator_version =
             retrieve_verilator_version(&options.verilator_executable)?;
         if let Some(allowed_version) = options.allow_unsupported_verilator {
@@ -547,10 +549,10 @@ impl VerilatorRuntime {
         }
 
         for source_file in source_files {
-            if !source_file.is_file() {
+            if !source_file.as_ref().is_file() {
                 whatever!(
                     "Source file {} does not exist or is not a file. Note that if it's a relative path, you must be in the correct directory",
-                    source_file
+                    source_file.as_ref().display()
                 );
             }
         }
@@ -578,16 +580,33 @@ impl VerilatorRuntime {
         };
 
         Ok(Self {
-            artifact_directory: artifact_directory.to_owned(),
+            artifact_directory: artifact_directory
+                .to_path_buf()
+                .try_into()
+                .whatever_context("Artifact directory path was not UTF-8")?,
             build_target,
             source_files: source_files
                 .iter()
-                .map(|path| path.to_path_buf())
-                .collect(),
+                .map(|path| {
+                    path.as_ref().to_path_buf().try_into().whatever_context(
+                        format!(
+                            "Source file {} was not UTF-8",
+                            path.as_ref().display()
+                        ),
+                    )
+                })
+                .collect::<Result<Vec<Utf8PathBuf>, _>>()?,
             include_directories: include_directories
                 .iter()
-                .map(|path| path.to_path_buf())
-                .collect(),
+                .map(|path| {
+                    path.as_ref().to_path_buf().try_into().whatever_context(
+                        format!(
+                            "Include directory {} was not UTF-8",
+                            path.as_ref().display()
+                        ),
+                    )
+                })
+                .collect::<Result<Vec<Utf8PathBuf>, _>>()?,
             dpi_functions: dpi_functions.into_iter().collect(),
             options,
             verilator_version,
@@ -660,9 +679,11 @@ impl VerilatorRuntime {
     /// the ports of the Verilog module.
     ///
     /// ```no_run
+    /// # use std::path::Path;
     /// # use marlin_verilator::*;
     /// # use marlin_verilator::dynamic::*;
-    /// # let runtime = VerilatorRuntime::new("".as_ref(), &[], &[], [], Default::default()).unwrap();
+    /// # let empty: &[&Path] = &[];
+    /// # let runtime = VerilatorRuntime::new("", empty, empty, [], Default::default()).unwrap();
     /// # || -> Result<(), snafu::Whatever> {
     /// let mut main = runtime.create_dyn_model(
     ///    "main",

--- a/verilator/src/lib.rs
+++ b/verilator/src/lib.rs
@@ -16,7 +16,7 @@ use core::convert::Into;
 use std::{
     cell::RefCell,
     cmp,
-    collections::{hash_map::Entry, HashMap},
+    collections::{HashMap, hash_map::Entry},
     ffi::{self, OsStr, OsString},
     fmt, fs,
     hash::{self, Hash, Hasher},
@@ -35,7 +35,7 @@ use dpi::DpiFunction;
 use dynamic::DynamicVerilatedModel;
 use libloading::Library;
 use owo_colors::OwoColorize;
-use snafu::{whatever, OptionExt, ResultExt, Whatever};
+use snafu::{OptionExt, ResultExt, Whatever, whatever};
 
 mod build_library;
 pub mod dpi;

--- a/verilator/src/lib.rs
+++ b/verilator/src/lib.rs
@@ -529,6 +529,23 @@ impl VerilatorRuntime {
     /// Creates a new runtime for instantiating (System)Verilog modules as Rust
     /// objects.
     pub fn new(
+        artifact_directory: &Path,
+        source_files: &[&Path],
+        include_directories: &[&Path],
+        dpi_functions: impl IntoIterator<Item = &'static dyn DpiFunction>,
+        options: VerilatorRuntimeOptions,
+    ) -> Result<Self, Whatever> {
+        Self::new2(
+            artifact_directory,
+            source_files,
+            include_directories,
+            dpi_functions,
+            options,
+        )
+    }
+
+    /// Convenient alternative to [`Self::new`].
+    pub fn new2(
         artifact_directory: impl AsRef<Path>,
         source_files: &[impl AsRef<Path>],
         include_directories: &[impl AsRef<Path>],


### PR DESCRIPTION
Fix #121